### PR TITLE
Add documentation for public members

### DIFF
--- a/src/Data/MediaType.purs
+++ b/src/Data/MediaType.purs
@@ -4,6 +4,10 @@ import Prelude
 
 import Data.Newtype (class Newtype)
 
+-- | A media type (also known as a **Multipurpose Internet Mail Extensions or
+-- | MIME type**) is a standard that indicates the nature and format of a
+-- | document, file, or assortment of bytes. It is defined and standardized in
+-- | IETF's [RFC 6838](https://tools.ietf.org/html/rfc6838).
 newtype MediaType = MediaType String
 
 derive instance newtypeMediaType :: Newtype MediaType _

--- a/src/Data/MediaType/Common.purs
+++ b/src/Data/MediaType/Common.purs
@@ -2,44 +2,58 @@ module Data.MediaType.Common where
 
 import Data.MediaType (MediaType(..))
 
+-- | The `application/x-www-form-urlencoded` media type.
 applicationFormURLEncoded :: MediaType
 applicationFormURLEncoded = MediaType "application/x-www-form-urlencoded"
 
+-- | The `application/json` media type.
 applicationJSON :: MediaType
 applicationJSON = MediaType "application/json"
 
+-- | The `application/javascript` media type.
 applicationJavascript :: MediaType
 applicationJavascript = MediaType "application/javascript"
 
+-- | The `application/octet-stream` media type.
 applicationOctetStream :: MediaType
 applicationOctetStream = MediaType "application/octet-stream"
 
+-- | The `application/xml` media type.
 applicationXML :: MediaType
 applicationXML = MediaType "application/xml"
 
+-- | The `image/gif` media type.
 imageGIF :: MediaType
 imageGIF = MediaType "image/gif"
 
+-- | The `image/jpeg` media type.
 imageJPEG :: MediaType
 imageJPEG = MediaType "image/jpeg"
 
+-- | The `image/png` media type.
 imagePNG :: MediaType
 imagePNG = MediaType "image/png"
 
+-- | The `multipart/form-data` media type.
 multipartFormData :: MediaType
 multipartFormData = MediaType "multipart/form-data"
 
+-- | The `text/csv` media type.
 textCSV :: MediaType
 textCSV = MediaType "text/csv"
 
+-- | The `text/html` media type.
 textHTML :: MediaType
 textHTML = MediaType "text/html"
 
+-- | The `text/plain` media type.
 textPlain :: MediaType
 textPlain = MediaType "text/plain"
 
+-- | The `text/xml` media type.
 textXML :: MediaType
 textXML = MediaType "text/xml"
 
+-- | The `text/css` media type.
 textCSS :: MediaType
 textCSS = MediaType "text/css"


### PR DESCRIPTION
This PR adds documentation for the public members exposed by the package.

This aims to satisfy the "module documentation" expectation set forth by the Contributors organization:

> 2. Have adequate documentation in the form of module documentation published to Pursuit, a README containing a library summary, installation instructions, and more, and a docs directory containing at least a short tutorial and a changelog (see the documentation section below).
>
> &mdash; [Expecations for Libraries](https://github.com/purescript-contrib/governance/blob/main/library-guidelines.md#expectations-for-libraries)
